### PR TITLE
Update README: Correct keypair generation command for eth keypair

### DIFF
--- a/README.md
+++ b/README.md
@@ -64,7 +64,7 @@ If you decide to have local keystores for your bn254 keypair and eth keypair, yo
 
 ```bash
 karak keypair generate --keystore local --curve bn254
-karak keypair generate --keystore local --curve eth
+karak keypair generate --keystore local --curve secp256k1
 ```
 
 ### Create a vault


### PR DESCRIPTION
Replace eth curve with secp256k1 in the keypair generation command to align with the supported options in karak-cli.